### PR TITLE
Switch Kafka image from bitnami to bitnamilegacy

### DIFF
--- a/docker/docker-compose.kafka-setup.yml
+++ b/docker/docker-compose.kafka-setup.yml
@@ -1,6 +1,6 @@
 services:
   kafkasetup:
-    image: docker.io/bitnami/kafka:3.8
+    image: docker.io/bitnamilegacy/kafka:3.8
     command: >
       bash -c 'unset JMX_PORT;
       for i in $$(seq 1 10); do

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - openepcis-net
 
   openepcis-kafka:
-    image: docker.io/bitnami/kafka:3.8
+    image: docker.io/bitnamilegacy/kafka:3.8
     container_name: openepcis-kafka
     environment:
       - ALLOW_PLAINTEXT_LISTENER=yes


### PR DESCRIPTION
Hello @sboeckelmann,
I want to contribute to this project, so I created this pull request.
If you think this change is unnecessary, please don't hesitate to close it.

As mentioned in Issue #2 , the bitnami/kafka container image is no longer publicly available, and Docker fails to pull it due to the tag deprecation.
According to Bitnami’s announcement, the image has been moved to the bitnamilegacy/kafka repository on Docker Hub.

This update changes the Kafka image reference to bitnamilegacy/kafka as a temporary workaround, and I’ve confirmed that the stack starts successfully in my environment.

Thank you for reviewing this PR!